### PR TITLE
Fix disk config

### DIFF
--- a/src/EloquentStorage.php
+++ b/src/EloquentStorage.php
@@ -85,7 +85,7 @@ class EloquentStorage extends Model
 
     private function getDisk()
     {
-        return Storage::disk(config('eloquentstorage.prod'));
+        return Storage::disk(config('eloquentstorage.driver'));
     }
 
     private function getFilePath()


### PR DESCRIPTION
configの引数で指定していた名前がconfigファイルのものと違ったため
設定ファイルの情報が適用されていなかった点の修正です