### PR TITLE
IE対応のためファイル名をSJIS-winに変換

### DIFF
--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -17,9 +17,10 @@ class EloquentStorageServiceProvider extends ServiceProvider
                 abort(404);
             }
             $fileName = $model->file_name;
+            $fileNameSjisWin = mb_convert_encoding($fileName, 'SJIS-win', 'UTF-8');
             $headers = [
                 'Content-Type' => 'application/octet-stream',
-                'Content-disposition' => "attachment; filename={$fileName}"
+                'Content-disposition' => "attachment; filename={$fileNameSjisWin}",
             ];
             return Response::make($content, $status, $headers);
         });


### PR DESCRIPTION
#5 

各ブラウザではファイル名の文字コードを自動的に変換してくれているが、
IEはやってくれないらしいので旧コードだと日本語が文字化けする。

ファイル名をSJIS-winに変換することでIEに対応させる

2ndMG側でvendorフォルダ内の該当ファイルを修正して動作確認済。

[![Image from Gyazo](https://i.gyazo.com/f409a4260edb9b9e6274b7f9f77ae3b7.gif)](https://gyazo.com/f409a4260edb9b9e6274b7f9f77ae3b7)