### PR TITLE
8 直接ダウンロードさせるマクロを追加

### DIFF
--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -26,7 +26,7 @@ class EloquentStorageServiceProvider extends ServiceProvider
         });
 
         Response::macro('openEloquentStorage', function (EloquentStorage $model, $status = 200, $mimeType = null) {
-            return self::createFileOpenRequest($model, $status, $mimeType);
+            return EloquentStorageServiceProvider::createFileOpenRequest($model, $status, $mimeType);
         });
 
         $this->publishes([

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -25,11 +25,12 @@ class EloquentStorageServiceProvider extends ServiceProvider
             return Response::make($content, $status, $headers);
         });
 
-        Response::macro('openEloquentStorage', function (EloquentStorage $model, $status = 200, $mimetype = null) {
+        $me = $this;
+        Response::macro('openEloquentStorage', function (EloquentStorage $model, $status = 200, $mimeType = null) use ($me) {
             $content = $model->getContent();
 
             $headers = [
-                'Content-Type' => $this->identifyFileType(),
+                'Content-Type' => $me->identifyFileType($content, $mimeType),
             ];
 
             return Response::make($content, $status, $headers);
@@ -40,20 +41,20 @@ class EloquentStorageServiceProvider extends ServiceProvider
         ]);
     }
 
-    private function identifyFileType($content, $mimetype = null): string
+    private function identifyFileType($content, $mimeType = null): string
     {
         $default = 'application/octet-stream';
-        if ($mimetype == null) {
+        if ($mimeType == null) {
             $fInfo = new finfo();
             $fInfoResult = $fInfo::buffer($content, FILEINFO_MIME_TYPE);
             return $fInfoResult !== false ? $fInfoResult : $default;
         }
 
-        if (is_callable($mimetype)) {
+        if (is_callable($mimeType)) {
             return $mimetype($content);
         }
 
-        return $mimetype;
+        return $mimeType;
     }
 
     public function register()

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -40,7 +40,7 @@ class EloquentStorageServiceProvider extends ServiceProvider
         ]);
     }
 
-    private function identifyFileType(string ?$content, $mimetype = null): string
+    private function identifyFileType($content, $mimetype = null): string
     {
         $default = 'application/octet-stream';
         if ($mimetype == null) {

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -25,15 +25,8 @@ class EloquentStorageServiceProvider extends ServiceProvider
             return Response::make($content, $status, $headers);
         });
 
-        $me = $this;
-        Response::macro('openEloquentStorage', function (EloquentStorage $model, $status = 200, $mimeType = null) use ($me) {
-            $content = $model->getContent();
-
-            $headers = [
-                'Content-Type' => $me->identifyFileType($content, $mimeType),
-            ];
-
-            return Response::make($content, $status, $headers);
+        Response::macro('openEloquentStorage', function (EloquentStorage $model, $status = 200, $mimeType = null) {
+            return self::createFileOpenRequest($model, $status, $mimeType);
         });
 
         $this->publishes([
@@ -41,7 +34,18 @@ class EloquentStorageServiceProvider extends ServiceProvider
         ]);
     }
 
-    private function identifyFileType($content, $mimeType = null): string
+    public static function createFileOpenRequest(EloquentStorage $model, $status = 200, $mimeType = null)
+    {
+            $content = $model->getContent();
+            $headers = [
+                'Content-Type' => self::identifyFileType($content, $mimeType),
+            ];
+
+            return Response::make($content, $status, $headers);
+
+    }
+
+    private static function identifyFileType($content, $mimeType = null): string
     {
         $default = 'application/octet-stream';
         if ($mimeType == null) {

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -51,7 +51,7 @@ class EloquentStorageServiceProvider extends ServiceProvider
         }
 
         if (is_callable($mimeType)) {
-            return $mimetype($content);
+            return $mimeType($content);
         }
 
         return $mimeType;

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -25,9 +25,35 @@ class EloquentStorageServiceProvider extends ServiceProvider
             return Response::make($content, $status, $headers);
         });
 
+        Response::macro('downloadEloquentStorage', function (EloquentStorage $model, $status = 200, $mimetype = null) {
+            $content = $model->getContent();
+
+            $headers = [
+                'Content-Type' => $this->identifyFileType(),
+            ];
+
+            return Response::make($content, $status, $headers);
+        });
+
         $this->publishes([
             __DIR__ . '/../config/eloquentstorage.php' => config_path('eloquentstorage.php')
         ]);
+    }
+
+    private function identifyFileType(string ?$content, $mimetype = null): string
+    {
+        $default = 'application/octet-stream';
+        if ($mimetype == null) {
+            $fInfo = new finfo();
+            $fInfoResult = $fInfo::buffer($content, FILEINFO_MIME_TYPE);
+            return $fInfoResult !== false ? $fInfoResult : $default;
+        }
+
+        if (is_callable($mimetype)) {
+            return $mimetype($content);
+        }
+
+        return $mimetype;
     }
 
     public function register()

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -49,8 +49,8 @@ class EloquentStorageServiceProvider extends ServiceProvider
     {
         $default = 'application/octet-stream';
         if ($mimeType == null) {
-            $fInfo = new finfo();
-            $fInfoResult = $fInfo::buffer($content, FILEINFO_MIME_TYPE);
+            $fInfo = new \finfo();
+            $fInfoResult = $fInfo->buffer($content, FILEINFO_MIME_TYPE);
             return $fInfoResult !== false ? $fInfoResult : $default;
         }
 

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -25,7 +25,7 @@ class EloquentStorageServiceProvider extends ServiceProvider
             return Response::make($content, $status, $headers);
         });
 
-        Response::macro('downloadEloquentStorage', function (EloquentStorage $model, $status = 200, $mimetype = null) {
+        Response::macro('openEloquentStorage', function (EloquentStorage $model, $status = 200, $mimetype = null) {
             $content = $model->getContent();
 
             $headers = [

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -42,7 +42,6 @@ class EloquentStorageServiceProvider extends ServiceProvider
             ];
 
             return Response::make($content, $status, $headers);
-
     }
 
     private static function identifyFileType($content, $mimeType = null): string


### PR DESCRIPTION
resolve #8

ファイルの判別は下記を使用した
https://www.php.net/manual/ja/function.finfo-buffer.php



ブラウザで開ける| openEloquentFileのレスポンス | downloadEloquentFileのレスポンス
-|-|-
![image](https://github.com/matchingood/laravel-eloquent-storage/assets/26814222/eece4ac7-496d-40e8-9787-c439239306e1)|![image](https://github.com/matchingood/laravel-eloquent-storage/assets/26814222/86cbd8bc-0119-4e56-93cf-60af1da091c8)|![image](https://github.com/matchingood/laravel-eloquent-storage/assets/26814222/76988e68-6785-4ce2-abb9-e3da8bd2b195)

