### PR TITLE
12  プレビュー時にファイル名を指定する

### DIFF
--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -59,9 +59,4 @@ class EloquentStorageServiceProvider extends ServiceProvider
 
         return $mimeType;
     }
-
-    public function register()
-    {
-        //
-    }
 }

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -41,12 +41,12 @@ class EloquentStorageServiceProvider extends ServiceProvider
 
     public static function createFileOpenRequest(EloquentStorage $model, $status = 200, $mimeType = null)
     {
-            $content = $model->getContent();
-            $headers = [
-                'Content-Type' => self::identifyFileType($content, $mimeType),
-            ];
+        $content = $model->getContent();
+        $headers = [
+            'Content-Type' => self::identifyFileType($content, $mimeType),
+        ];
 
-            return Response::make($content, $status, $headers);
+        return Response::make($content, $status, $headers);
     }
 
     private static function identifyFileType($content, $mimeType = null): string

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -70,6 +70,7 @@ class EloquentStorageServiceProvider extends ServiceProvider
     private static function formatContentDisposition($dispositionType, $filename)
     {
         $filenameSjisWin = mb_convert_encoding($filename, 'SJIS-win', 'UTF-8');
-        return "{$dispositionType}; filename={$filenameSjisWin}";
+        $extendName = urlencode($filename);
+        return "{$dispositionType}; filename={$filenameSjisWin}; filename*=UTF-8''{$extendName}";
     }
 }

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -8,6 +8,9 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class EloquentStorageServiceProvider extends ServiceProvider
 {
+    const DISPOSITION_TYPE_ATTACHMENT = 'attachment';
+    const DISPOSITION_TYPE_INLINE = 'inline';
+
     public function boot()
     {
         Response::macro('downloadEloquentStorage', function (EloquentStorage $model, $status = 200) {
@@ -31,10 +34,9 @@ class EloquentStorageServiceProvider extends ServiceProvider
             abort(404);
         }
         $fileName = $model->file_name;
-        $fileNameSjisWin = mb_convert_encoding($fileName, 'SJIS-win', 'UTF-8');
         $headers = [
             'Content-Type' => 'application/octet-stream',
-            'Content-disposition' => "attachment; filename={$fileNameSjisWin}",
+            'Content-Disposition' => self::formatContentDisposition(self::DISPOSITION_TYPE_ATTACHMENT, $fileName),
         ];
         return Response::make($content, $status, $headers);
     }
@@ -63,5 +65,11 @@ class EloquentStorageServiceProvider extends ServiceProvider
         }
 
         return $mimeType;
+    }
+
+    private static function formatContentDisposition($dispositionType, $filename)
+    {
+        $filenameSjisWin = mb_convert_encoding($filename, 'SJIS-win', 'UTF-8');
+        return "{$dispositionType}; filename={$filenameSjisWin}";
     }
 }

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -69,8 +69,9 @@ class EloquentStorageServiceProvider extends ServiceProvider
 
     private static function formatContentDisposition($dispositionType, $filename)
     {
-        $filenameSjisWin = mb_convert_encoding($filename, 'SJIS-win', 'UTF-8');
+        $safeAscii = iconv('UTF-8', 'ASCII//IGNORE', $filename);
         $extendName = urlencode($filename);
-        return "{$dispositionType}; filename={$filenameSjisWin}; filename*=UTF-8''{$extendName}";
+        // RFC 6266 Section 4.1
+        return "{$dispositionType}; filename=\"{$safeAscii}\"; filename*=UTF-8''{$extendName}";
     }
 }

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -11,18 +11,7 @@ class EloquentStorageServiceProvider extends ServiceProvider
     public function boot()
     {
         Response::macro('downloadEloquentStorage', function (EloquentStorage $model, $status = 200) {
-            try {
-                $content = $model->getContent();
-            } catch (FileNotFoundException $e) {
-                abort(404);
-            }
-            $fileName = $model->file_name;
-            $fileNameSjisWin = mb_convert_encoding($fileName, 'SJIS-win', 'UTF-8');
-            $headers = [
-                'Content-Type' => 'application/octet-stream',
-                'Content-disposition' => "attachment; filename={$fileNameSjisWin}",
-            ];
-            return Response::make($content, $status, $headers);
+            return EloquentStorageServiceProvider::createFileDownloadRequest($model, $status);
         });
 
         Response::macro('openEloquentStorage', function (EloquentStorage $model, $status = 200, $mimeType = null) {
@@ -32,6 +21,22 @@ class EloquentStorageServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../config/eloquentstorage.php' => config_path('eloquentstorage.php')
         ]);
+    }
+
+    public static function createFileDownloadRequest(EloquentStorage $model, $status = 200)
+    {
+        try {
+            $content = $model->getContent();
+        } catch (FileNotFoundException $e) {
+            abort(404);
+        }
+        $fileName = $model->file_name;
+        $fileNameSjisWin = mb_convert_encoding($fileName, 'SJIS-win', 'UTF-8');
+        $headers = [
+            'Content-Type' => 'application/octet-stream',
+            'Content-disposition' => "attachment; filename={$fileNameSjisWin}",
+        ];
+        return Response::make($content, $status, $headers);
     }
 
     public static function createFileOpenRequest(EloquentStorage $model, $status = 200, $mimeType = null)

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -33,10 +33,9 @@ class EloquentStorageServiceProvider extends ServiceProvider
         } catch (FileNotFoundException $e) {
             abort(404);
         }
-        $fileName = $model->file_name;
         $headers = [
             'Content-Type' => 'application/octet-stream',
-            'Content-Disposition' => self::formatContentDisposition(self::DISPOSITION_TYPE_ATTACHMENT, $fileName),
+            'Content-Disposition' => self::formatContentDisposition(self::DISPOSITION_TYPE_ATTACHMENT, $model->file_name),
         ];
         return Response::make($content, $status, $headers);
     }
@@ -46,6 +45,7 @@ class EloquentStorageServiceProvider extends ServiceProvider
         $content = $model->getContent();
         $headers = [
             'Content-Type' => self::identifyFileType($content, $mimeType),
+            'Content-Disposition' => self::formatContentDisposition(self::DISPOSITION_TYPE_INLINE, $model->file_name),
         ];
 
         return Response::make($content, $status, $headers);

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -26,6 +26,9 @@ class EloquentStorageServiceProvider extends ServiceProvider
         ]);
     }
 
+    /**
+     * ファイルをダウンロードして保存させるためのレスポンスを作成する
+     */
     public static function createFileDownloadRequest(EloquentStorage $model, $status = 200)
     {
         try {
@@ -40,6 +43,9 @@ class EloquentStorageServiceProvider extends ServiceProvider
         return Response::make($content, $status, $headers);
     }
 
+    /**
+     * ファイルをブラウザ上で開かせるためのレスポンスを作成する
+     */
     public static function createFileOpenRequest(EloquentStorage $model, $status = 200, $mimeType = null)
     {
         $content = $model->getContent();
@@ -67,7 +73,13 @@ class EloquentStorageServiceProvider extends ServiceProvider
         return $mimeType;
     }
 
-    private static function formatContentDisposition($dispositionType, $filename)
+    /**
+     * Content-Disposition の内容を生成する
+     * @param string $dispositionType attachment または inline、self::DISPOSITION_TYPE_* 
+     * @param string $filename UTF-8でエンコードされたファイル名
+     * @return string Content-Disposition の内容
+     */
+    private static function formatContentDisposition($dispositionType, $filename): string
     {
         $safeAscii = iconv('UTF-8', 'ASCII//IGNORE', $filename);
         $extendName = urlencode($filename);

--- a/src/EloquentStorageServiceProvider.php
+++ b/src/EloquentStorageServiceProvider.php
@@ -28,6 +28,7 @@ class EloquentStorageServiceProvider extends ServiceProvider
 
     /**
      * ファイルをダウンロードして保存させるためのレスポンスを作成する
+     * @remark macroから呼び出すため、publicである必要がある
      */
     public static function createFileDownloadRequest(EloquentStorage $model, $status = 200)
     {
@@ -45,6 +46,7 @@ class EloquentStorageServiceProvider extends ServiceProvider
 
     /**
      * ファイルをブラウザ上で開かせるためのレスポンスを作成する
+     * @remark macroから呼び出すため、publicである必要がある
      */
     public static function createFileOpenRequest(EloquentStorage $model, $status = 200, $mimeType = null)
     {


### PR DESCRIPTION
resolve #12 

## What

#9 で`Content-Disposition`を指定しないことで、明示的にダウンロードさせず
直接ブラウザなどで開くようにしたが、ファイル名が指定できないので
`Content-Disposition`で`inline`を指定することで、同等の挙動になるように期待する。

## How

- feat: open時に`Content-Disposition`を`inline`で指定
- feat: `filename*`でUTF-8のファイル名を指定
- fix: `filename`にはShiftJISではなくダブルクォートしたASCIIを指定するようにした
- refactor: マクロ登録とその実装を分けた
- refactor: `Content-Disposition`の生成を関数化した

今回の修正でIEではうまくいかなくなるかもしれない

## Content-Dispositionの実装の参考

https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/HttpFoundation/HeaderUtils.php#L165
https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php#L155
https://github.com/matchingood/matchingood/blob/ad797a8baac303e8215998e687793cadf1da9bd6/lib/Util.class.php#L3214
https://github.com/laravel/framework/blob/841d842bbdc8e08c6364a8c06212c7286bbf0b9a/src/Illuminate/Routing/ResponseFactory.php#L163
https://github.com/laravel/framework/blob/841d842bbdc8e08c6364a8c06212c7286bbf0b9a/src/Illuminate/Routing/ResponseFactory.php#L180

## 各ブラウザの動作テスト

下記PRを確認すること
- https://github.com/matchingood/2nd-matchingood/pull/32755